### PR TITLE
Updating _assets.html.erb to escape description field

### DIFF
--- a/app/views/hot_buttons/_assets.html.erb
+++ b/app/views/hot_buttons/_assets.html.erb
@@ -9,6 +9,9 @@
 
   i18n_strings = I18n.backend.send(:translations)
   locale = I18n.locale
+  
+  #escaping issue description as script tags were breaking rendering
+  @issue.description = html_escape(@issue.description)
 
 %>
 <% content_for :header_tags do %>


### PR DESCRIPTION
We found that if there was a </script> in the description field of an issue (which happens reasonably often when posting code or google analytics info) then the javascript would break and the issue would no longer be rendered correctly. 

Not sure if this is the correct way to fix this, but it seems to work here.
