### PR TITLE
Make this plugin compatible with CKEditor plugin 

### DIFF
--- a/assets/javascripts/hot_buttons.js
+++ b/assets/javascripts/hot_buttons.js
@@ -579,6 +579,15 @@ jQuery(document).ready(function() {
           case 'include_comment':
             var include_comment = button.config.get('include_comment').evalJSON();
             if (include_comment) {
+              //Fix to make this plugin compatible with CKEditor plugin
+              if (CKEDITOR && CKEDITOR.instances["issue_notes"]) {
+                //destroy CKEDITOR so it won't replace notes text with his empty value on submit
+                try {
+                  CKEDITOR.instances["issue_notes"].destroy()
+                } catch(ex) {
+                  //nothing to do.
+                }
+              }
               $P('issue_notes').value = button.up().select('textarea.notes').first().value;
             }
             break;


### PR DESCRIPTION
If CKeditor plugin is in use, any attempt to make user insert a quick comment via hot-button is nulled as CKeditor replace the content of the hidden note textarea with his empty value that, at time of hot-button submit is an empty-string.

This fix kindly kill CKeditor just before hot-button submit, so the textarea content set by hot-button is kept.

Hope this help